### PR TITLE
Add comprehensive moderation commands

### DIFF
--- a/commands/ban.js
+++ b/commands/ban.js
@@ -1,0 +1,44 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ban')
+    .setDescription('Ban a user from the server')
+    .addUserOption(opt => opt.setName('user').setDescription('User to ban').setRequired(true))
+    .addStringOption(opt => opt.setName('reason').setDescription('Reason').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
+  async execute(interaction) {
+    const user = interaction.options.getUser('user');
+    const reason = interaction.options.getString('reason') || 'No reason provided';
+    const caseId = uuidv4().split('-')[0];
+
+    await interaction.guild.members.ban(user.id, { reason }).catch(() => {});
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: user.id,
+      moderatorId: interaction.user.id,
+      action: 'Ban',
+      reason,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('🔨 User Banned')
+      .addFields(
+        { name: 'User', value: `<@${user.id}>`, inline: true },
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Reason', value: reason, inline: false },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setColor(0xc0392b)
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -1,0 +1,45 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('kick')
+    .setDescription('Kick a user from the server')
+    .addUserOption(opt => opt.setName('user').setDescription('User to kick').setRequired(true))
+    .addStringOption(opt => opt.setName('reason').setDescription('Reason').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+
+  async execute(interaction) {
+    const member = interaction.options.getMember('user');
+    if (!member) return interaction.reply({ content: '❌ Member not found.', ephemeral: true });
+    const reason = interaction.options.getString('reason') || 'No reason provided';
+    const caseId = uuidv4().split('-')[0];
+
+    await member.kick(reason).catch(() => {});
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: member.id,
+      moderatorId: interaction.user.id,
+      action: 'Kick',
+      reason,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('👢 User Kicked')
+      .addFields(
+        { name: 'User', value: `<@${member.id}>`, inline: true },
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Reason', value: reason, inline: false },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setColor(0xe74c3c)
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/lock.js
+++ b/commands/lock.js
@@ -1,0 +1,39 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+const ModCase = require('../models/ModCase');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('lock')
+    .setDescription('Lock a channel')
+    .addChannelOption(opt => opt.setName('channel').setDescription('Channel').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+  async execute(interaction) {
+    const channel = interaction.options.getChannel('channel') || interaction.channel;
+    await channel.permissionOverwrites.edit(interaction.guild.roles.everyone, { SendMessages: false });
+
+    const caseId = uuidv4().split('-')[0];
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: 'N/A',
+      moderatorId: interaction.user.id,
+      action: 'Lock',
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('Channel Locked')
+      .setDescription(`<#${channel.id}> locked`)
+      .setColor(0xe74c3c)
+      .addFields(
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/modlogs.js
+++ b/commands/modlogs.js
@@ -1,0 +1,29 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const Warning = require('../models/Warning');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('modlogs')
+    .setDescription('View moderation logs for a user')
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+
+  async execute(interaction) {
+    const user = interaction.options.getUser('user');
+    const cases = await ModCase.find({ guildId: interaction.guildId, userId: user.id }).lean();
+    const warns = await Warning.find({ guildId: interaction.guildId, userId: user.id }).lean();
+    const combined = [...cases, ...warns.map(w => ({ ...w, action: 'Warn' }))];
+    if (!combined.length) {
+      return interaction.reply({ content: '✅ No moderation history.', ephemeral: true });
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Moderation Logs for ${user.tag}`)
+      .setColor(0x7289da)
+      .setDescription(combined.map(c => `**${c.action}** - ${c.reason || 'No reason'} (Case ${c.caseId})`).join('\n'))
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+};

--- a/commands/mute.js
+++ b/commands/mute.js
@@ -1,0 +1,55 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+const parseDuration = require('../utils/parseDuration');
+const { v4: uuidv4 } = require('uuid');
+
+const MUTE_ROLE_ID = process.env.MUTE_ROLE_ID;
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('mute')
+    .setDescription('Mute a user by role')
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+    .addStringOption(opt => opt.setName('duration').setDescription('Duration e.g. 10m').setRequired(false))
+    .addStringOption(opt => opt.setName('reason').setDescription('Reason').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+
+  async execute(interaction) {
+    if (!MUTE_ROLE_ID) return interaction.reply({ content: 'Mute role not configured.', ephemeral: true });
+    const member = interaction.options.getMember('user');
+    if (!member) return interaction.reply({ content: '❌ Member not found.', ephemeral: true });
+    const durationStr = interaction.options.getString('duration');
+    const duration = durationStr ? parseDuration(durationStr) : null;
+    const reason = interaction.options.getString('reason') || 'No reason provided';
+    const caseId = uuidv4().split('-')[0];
+
+    await member.roles.add(MUTE_ROLE_ID).catch(() => {});
+    if (duration) setTimeout(() => member.roles.remove(MUTE_ROLE_ID).catch(() => {}), duration);
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: member.id,
+      moderatorId: interaction.user.id,
+      action: 'Mute',
+      reason,
+      duration,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('🔇 User Muted')
+      .addFields(
+        { name: 'User', value: `<@${member.id}>`, inline: true },
+        ...(durationStr ? [{ name: 'Duration', value: durationStr, inline: true }] : []),
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Reason', value: reason, inline: false },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setColor(0x95a5a6)
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/purge.js
+++ b/commands/purge.js
@@ -1,0 +1,46 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const logModeration = require('../utils/modLog');
+const { EmbedBuilder } = require('discord.js');
+const { v4: uuidv4 } = require('uuid');
+const ModCase = require('../models/ModCase');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('purge')
+    .setDescription('Delete a number of messages')
+    .addIntegerOption(opt => opt.setName('amount').setDescription('Number of messages').setRequired(true))
+    .addUserOption(opt => opt.setName('user').setDescription('Only messages from user').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages),
+
+  async execute(interaction) {
+    const amount = interaction.options.getInteger('amount');
+    const target = interaction.options.getUser('user');
+    const messages = await interaction.channel.messages.fetch({ limit: amount });
+    let toDelete = messages;
+    if (target) toDelete = messages.filter(m => m.author.id === target.id);
+    await interaction.channel.bulkDelete(toDelete, true);
+
+    const caseId = uuidv4().split('-')[0];
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: target ? target.id : 'N/A',
+      moderatorId: interaction.user.id,
+      action: 'Purge',
+      reason: `${amount} messages deleted`,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('Messages Purged')
+      .setDescription(`${toDelete.size} messages deleted`)
+      .setColor(0x7289da)
+      .addFields(
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/removewarn.js
+++ b/commands/removewarn.js
@@ -1,0 +1,31 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const Warning = require('../models/Warning');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('removewarn')
+    .setDescription('Remove a warning by case ID')
+    .addStringOption(opt => opt.setName('case').setDescription('Case ID').setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+
+  async execute(interaction) {
+    const caseId = interaction.options.getString('case');
+    const warn = await Warning.findOneAndDelete({ guildId: interaction.guildId, caseId });
+    if (!warn) {
+      return interaction.reply({ content: '❌ Warning not found.', ephemeral: true });
+    }
+
+    await ModCase.deleteOne({ guildId: interaction.guildId, caseId });
+
+    const content = `Warning ${caseId} removed for <@${warn.userId}>.`;
+    await interaction.reply({ content, ephemeral: true });
+
+    const { EmbedBuilder } = require('discord.js');
+    const embed = new EmbedBuilder()
+      .setDescription(content)
+      .setColor(0x3498db);
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/slowmode.js
+++ b/commands/slowmode.js
@@ -1,0 +1,44 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+const ModCase = require('../models/ModCase');
+const parseDuration = require('../utils/parseDuration');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('slowmode')
+    .setDescription('Set slowmode for this channel')
+    .addStringOption(opt => opt.setName('duration').setDescription('Duration e.g. 5s').setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+  async execute(interaction) {
+    const durationStr = interaction.options.getString('duration');
+    const duration = parseDuration(durationStr);
+    if (duration === null) return interaction.reply({ content: '❌ Invalid duration.', ephemeral: true });
+    const seconds = duration / 1000;
+    await interaction.channel.setRateLimitPerUser(seconds);
+
+    const caseId = uuidv4().split('-')[0];
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: 'N/A',
+      moderatorId: interaction.user.id,
+      action: 'Slowmode',
+      reason: `${seconds}s`,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('Slowmode Updated')
+      .setDescription(`Slowmode set to ${seconds}s`)
+      .setColor(0x3498db)
+      .addFields(
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/softban.js
+++ b/commands/softban.js
@@ -1,0 +1,45 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('softban')
+    .setDescription('Softban (ban and unban) a user to delete messages')
+    .addUserOption(opt => opt.setName('user').setDescription('User to softban').setRequired(true))
+    .addStringOption(opt => opt.setName('reason').setDescription('Reason').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
+  async execute(interaction) {
+    const user = interaction.options.getUser('user');
+    const reason = interaction.options.getString('reason') || 'No reason provided';
+    const caseId = uuidv4().split('-')[0];
+
+    await interaction.guild.members.ban(user.id, { reason, deleteMessageSeconds: 604800 }).catch(() => {});
+    await interaction.guild.members.unban(user.id).catch(() => {});
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: user.id,
+      moderatorId: interaction.user.id,
+      action: 'Softban',
+      reason,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('User Softbanned')
+      .addFields(
+        { name: 'User', value: `<@${user.id}>`, inline: true },
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Reason', value: reason, inline: false },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setColor(0xe67e22)
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/timeout.js
+++ b/commands/timeout.js
@@ -1,0 +1,52 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+const parseDuration = require('../utils/parseDuration');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('timeout')
+    .setDescription('Timeout a user')
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+    .addStringOption(opt => opt.setName('duration').setDescription('Duration e.g. 10m').setRequired(true))
+    .addStringOption(opt => opt.setName('reason').setDescription('Reason').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+
+  async execute(interaction) {
+    const member = interaction.options.getMember('user');
+    if (!member) return interaction.reply({ content: '❌ Member not found.', ephemeral: true });
+    const durationStr = interaction.options.getString('duration');
+    const duration = parseDuration(durationStr);
+    if (!duration) return interaction.reply({ content: '❌ Invalid duration.', ephemeral: true });
+    const reason = interaction.options.getString('reason') || 'No reason provided';
+    const caseId = uuidv4().split('-')[0];
+
+    await member.timeout(duration, reason).catch(() => {});
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: member.id,
+      moderatorId: interaction.user.id,
+      action: 'Timeout',
+      reason,
+      duration,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('⏱️ User Timed Out')
+      .addFields(
+        { name: 'User', value: `<@${member.id}>`, inline: true },
+        { name: 'Duration', value: durationStr, inline: true },
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Reason', value: reason, inline: false },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setColor(0xf1c40f)
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/unlock.js
+++ b/commands/unlock.js
@@ -1,0 +1,39 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+const ModCase = require('../models/ModCase');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('unlock')
+    .setDescription('Unlock a channel')
+    .addChannelOption(opt => opt.setName('channel').setDescription('Channel').setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+  async execute(interaction) {
+    const channel = interaction.options.getChannel('channel') || interaction.channel;
+    await channel.permissionOverwrites.edit(interaction.guild.roles.everyone, { SendMessages: null });
+
+    const caseId = uuidv4().split('-')[0];
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: 'N/A',
+      moderatorId: interaction.user.id,
+      action: 'Unlock',
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('Channel Unlocked')
+      .setDescription(`<#${channel.id}> unlocked`)
+      .setColor(0x2ecc71)
+      .addFields(
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/unmute.js
+++ b/commands/unmute.js
@@ -1,0 +1,44 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+
+const MUTE_ROLE_ID = process.env.MUTE_ROLE_ID;
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('unmute')
+    .setDescription('Remove mute from a user')
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+
+  async execute(interaction) {
+    if (!MUTE_ROLE_ID) return interaction.reply({ content: 'Mute role not configured.', ephemeral: true });
+    const member = interaction.options.getMember('user');
+    if (!member) return interaction.reply({ content: '❌ Member not found.', ephemeral: true });
+    const caseId = uuidv4().split('-')[0];
+
+    await member.roles.remove(MUTE_ROLE_ID).catch(() => {});
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: member.id,
+      moderatorId: interaction.user.id,
+      action: 'Unmute',
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('User Unmuted')
+      .addFields(
+        { name: 'User', value: `<@${member.id}>`, inline: true },
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setColor(0x1abc9c)
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/untimeout.js
+++ b/commands/untimeout.js
@@ -1,0 +1,41 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('untimeout')
+    .setDescription('Remove timeout from a user')
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+
+  async execute(interaction) {
+    const member = interaction.options.getMember('user');
+    if (!member) return interaction.reply({ content: '❌ Member not found.', ephemeral: true });
+    const caseId = uuidv4().split('-')[0];
+
+    await member.timeout(null).catch(() => {});
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: member.id,
+      moderatorId: interaction.user.id,
+      action: 'Untimeout',
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('Timeout Removed')
+      .addFields(
+        { name: 'User', value: `<@${member.id}>`, inline: true },
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setColor(0x2ecc71)
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/warn.js
+++ b/commands/warn.js
@@ -1,0 +1,55 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const { v4: uuidv4 } = require('uuid');
+const Warning = require('../models/Warning');
+const ModCase = require('../models/ModCase');
+const logModeration = require('../utils/modLog');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('warn')
+    .setDescription('Issue a warning to a user')
+    .addUserOption(opt =>
+      opt.setName('user').setDescription('User to warn').setRequired(true)
+    )
+    .addStringOption(opt =>
+      opt.setName('reason').setDescription('Reason for warning').setRequired(true)
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+
+  async execute(interaction) {
+    const user = interaction.options.getUser('user');
+    const reason = interaction.options.getString('reason');
+    const caseId = uuidv4().split('-')[0];
+
+    await Warning.create({
+      guildId: interaction.guildId,
+      userId: user.id,
+      moderatorId: interaction.user.id,
+      reason,
+      caseId
+    });
+
+    await ModCase.create({
+      guildId: interaction.guildId,
+      userId: user.id,
+      moderatorId: interaction.user.id,
+      action: 'Warn',
+      reason,
+      caseId
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('⚠️ User Warned')
+      .setColor(0xe67e22)
+      .addFields(
+        { name: 'User', value: `<@${user.id}>`, inline: true },
+        { name: 'Moderator', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Reason', value: reason, inline: false },
+        { name: 'Case ID', value: caseId, inline: true }
+      )
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+    await logModeration(interaction.guild, embed);
+  }
+};

--- a/commands/warnings.js
+++ b/commands/warnings.js
@@ -1,0 +1,27 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const Warning = require('../models/Warning');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('warnings')
+    .setDescription('View warnings for a user')
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+
+  async execute(interaction) {
+    const user = interaction.options.getUser('user');
+    const warns = await Warning.find({ guildId: interaction.guildId, userId: user.id }).lean();
+
+    if (!warns.length) {
+      return interaction.reply({ content: '✅ No warnings found for this user.', ephemeral: true });
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Warnings for ${user.tag}`)
+      .setColor(0xe67e22)
+      .setDescription(warns.map(w => `**${w.caseId}** - ${w.reason}`).join('\n'))
+      .setTimestamp();
+
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+};

--- a/models/ModCase.js
+++ b/models/ModCase.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const modCaseSchema = new mongoose.Schema({
+  guildId: { type: String, required: true },
+  userId: { type: String, required: true },
+  moderatorId: { type: String, required: true },
+  action: { type: String, required: true },
+  reason: { type: String },
+  duration: { type: Number },
+  caseId: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('ModCase', modCaseSchema);

--- a/models/Warning.js
+++ b/models/Warning.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const warningSchema = new mongoose.Schema({
+  guildId: { type: String, required: true },
+  userId: { type: String, required: true },
+  moderatorId: { type: String, required: true },
+  reason: { type: String, required: true },
+  caseId: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Warning', warningSchema);

--- a/utils/modLog.js
+++ b/utils/modLog.js
@@ -1,0 +1,15 @@
+const { EmbedBuilder } = require('discord.js');
+
+module.exports = async function logModeration(guild, embedContent) {
+  const channelId = process.env.MOD_LOG_CHANNEL_ID;
+  if (!channelId) return;
+
+  try {
+    const channel = await guild.channels.fetch(channelId);
+    if (channel && channel.isTextBased()) {
+      await channel.send({ embeds: [embedContent] });
+    }
+  } catch (err) {
+    console.error('❌ Failed to log moderation action:', err);
+  }
+};

--- a/utils/parseDuration.js
+++ b/utils/parseDuration.js
@@ -1,0 +1,9 @@
+module.exports = function parseDuration(str) {
+  if (!str) return null;
+  const match = /^([0-9]+)([smhd])$/i.exec(str.trim());
+  if (!match) return null;
+  const num = parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+  const multipliers = { s: 1000, m: 60000, h: 3600000, d: 86400000 };
+  return num * (multipliers[unit] || 0);
+};


### PR DESCRIPTION
## Summary
- build out mod actions for warnings, bans, kicks and timeouts
- create a reusable `ModCase` model and helper to parse short durations
- add role-based mutes, channel tools and log viewer commands

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854bdd07f948330a2619b8b9f8d2345