### PR TITLE
Auto register Discord commands on startup

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,30 +1,4 @@
-require("dotenv").config();
-const { REST, Routes } = require("discord.js");
-const fs = require("fs");
+require('dotenv').config();
+const registerCommands = require('./utils/registerCommands');
 
-const commands = [];
-const commandFiles = fs.readdirSync("./commands").filter(file => file.endsWith(".js"));
-
-for (const file of commandFiles) {
-  const command = require(`./commands/${file}`);
-  if (!command.data || !command.data.toJSON) {
-    console.error(`❌ Skipping ${file}: .data or .toJSON() is missing or malformed.`);
-    continue;
-  }
-  commands.push(command.data.toJSON());
-}
-
-const rest = new REST({ version: "10" }).setToken(process.env.DISCORD_TOKEN);
-
-(async () => {
-  try {
-    console.log("🔄 Refreshing application commands...");
-    await rest.put(
-      Routes.applicationCommands(process.env.CLIENT_ID),
-      { body: commands }
-    );
-    console.log("✅ Commands successfully registered.");
-  } catch (error) {
-    console.error("❌ Error registering commands:", error);
-  }
-})();
+registerCommands();

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const createSecureInvite = require("./utils/createSecureInvite");
 const { startApplication } = require("./applicationSessionHandler"); // place at top of index.js
 const activeShifts = new Map();
 const summarizeShifts = require('./utils/weeklyShiftSummary');
+const registerCommands = require('./utils/registerCommands');
 
 const SHIFT_LOG_CHANNELS = {
   '1372312806107512894': '1376607799622238469', // Xbox server → Xbox log
@@ -635,8 +636,10 @@ if (interaction.isStringSelectMenu() && interaction.customId === "application_ty
 
 client.once("ready", async () => {
   console.log(`✅ Logged in as ${client.user.tag}`);
-  
-globalThis.discordClient = client;
+
+  await registerCommands();
+
+  globalThis.discordClient = client;
   
   const forum = await client.channels.fetch('1374934648857034863');
   console.log("Available tags:", forum.availableTags);

--- a/utils/registerCommands.js
+++ b/utils/registerCommands.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const { REST, Routes } = require('discord.js');
+
+module.exports = async function registerCommands() {
+  const commandsDir = path.join(__dirname, '..', 'commands');
+  const commandFiles = fs.readdirSync(commandsDir).filter(f => f.endsWith('.js'));
+
+  const commandData = [];
+  for (const file of commandFiles) {
+    const cmdPath = path.join(commandsDir, file);
+    const command = require(cmdPath);
+    if (!command.data || !command.data.toJSON) {
+      console.error(`❌ Skipping ${file}: .data or .toJSON() is missing or malformed.`);
+      continue;
+    }
+    commandData.push({ name: command.data.name, json: command.data.toJSON() });
+  }
+
+  const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+
+  console.log('🔄 Refreshing application commands...');
+  try {
+    await rest.put(
+      Routes.applicationCommands(process.env.CLIENT_ID),
+      { body: commandData.map(c => c.json) }
+    );
+    console.log(`✅ Registered ${commandData.length} commands:`);
+    for (const c of commandData) {
+      console.log(`   - ${c.name}`);
+    }
+  } catch (error) {
+    console.error('❌ Error registering commands:', error);
+  }
+};


### PR DESCRIPTION
## Summary
- implement `registerCommands` utility for registering slash commands
- use new utility in `deploy-commands.js` and during bot startup

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854c97dcee4833095873bf318b56cc1