### PR TITLE
Add manual shift summary command

### DIFF
--- a/commands/shift-summary.js
+++ b/commands/shift-summary.js
@@ -1,0 +1,20 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const summarizeShifts = require('../utils/weeklyShiftSummary');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('shift-summary')
+    .setDescription('Manually summarize and clear weekly shifts')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
+
+  async execute(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+    try {
+      await summarizeShifts(interaction.client);
+      await interaction.editReply('✅ Shift summary generated.');
+    } catch (err) {
+      console.error('❌ Error summarizing shifts:', err);
+      await interaction.editReply('❌ Failed to summarize shifts.');
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `/shift-summary` command to manually summarize shifts
- improve weekly summary by clearing logs after posting and handling missing channels

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859da7b7f50833094f92acfb86300c4