### PR TITLE
Implement priority request system

### DIFF
--- a/commands/priority.js
+++ b/commands/priority.js
@@ -1,0 +1,79 @@
+const { SlashCommandBuilder, PermissionFlagsBits, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { v4: uuidv4 } = require('uuid');
+const Priority = require('../models/Priority');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('priority')
+    .setDescription('Request a priority scene')
+    .addStringOption(opt =>
+      opt.setName('type').setDescription('Priority type').setRequired(true)
+        .addChoices(
+          { name: '10-70', value: '10-70' },
+          { name: '10-80', value: '10-80' },
+          { name: 'Hostage', value: 'Hostage' }
+        ))
+    .addStringOption(opt =>
+      opt.setName('reason').setDescription('Scene reason').setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('duration').setDescription('Estimated duration in minutes'))
+    .addStringOption(opt =>
+      opt.setName('participants').setDescription('Other participants (IDs or mentions)'))
+    .setDefaultMemberPermissions(PermissionFlagsBits.SendMessages),
+
+  async execute(interaction) {
+    const guildId = interaction.guildId;
+    const existing = await Priority.findOne({ guildId, status: { $in: ['pending', 'approved', 'active'] } });
+    if (existing) {
+      return interaction.reply({ content: '❌ A priority is already pending or active for this server.', ephemeral: true });
+    }
+
+    const type = interaction.options.getString('type');
+    const reason = interaction.options.getString('reason');
+    const duration = interaction.options.getString('duration');
+    const participantsRaw = interaction.options.getString('participants') || '';
+    const participants = participantsRaw.split(/\s+/).filter(Boolean);
+    const requestId = uuidv4();
+
+    await Priority.create({
+      guildId,
+      requestId,
+      requesterId: interaction.user.id,
+      participants,
+      type,
+      reason,
+      estimatedDuration: duration ? Number(duration) : undefined,
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('Priority Request')
+      .setColor(0x2B2D31)
+      .addFields(
+        { name: 'Requester', value: `<@${interaction.user.id}>`, inline: true },
+        { name: 'Type', value: type, inline: true },
+        { name: 'Reason', value: reason },
+        { name: 'Participants', value: participants.length ? participants.join(', ') : 'None' },
+        ...(duration ? [{ name: 'Estimated', value: `${duration} min`, inline: true }] : [])
+      )
+      .setFooter({ text: `Request ID: ${requestId}` });
+
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId(`priority_accept_${requestId}`).setLabel('Accept').setStyle(ButtonStyle.Success),
+      new ButtonBuilder().setCustomId(`priority_deny_${requestId}`).setLabel('Deny').setStyle(ButtonStyle.Danger)
+    );
+
+    const channels = {
+      '1372312806107512894': process.env.XBOX_PRIORITY_REQUEST_CHANNEL_ID,
+      '1369495333574545559': process.env.PS_PRIORITY_REQUEST_CHANNEL_ID,
+    };
+
+    const channelId = channels[guildId];
+    const channel = channelId ? await interaction.client.channels.fetch(channelId).catch(() => null) : null;
+    if (!channel) {
+      return interaction.reply({ content: '❌ Priority request channel not configured.', ephemeral: true });
+    }
+
+    await channel.send({ embeds: [embed], components: [row] });
+    await interaction.reply({ content: '✅ Priority request submitted for staff review.', ephemeral: true });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -29,6 +29,16 @@ const SHIFT_LOG_CHANNELS = {
   '1369495333574545559': '1376607873945174119', // PS server → PS log
 };
 
+const PRIORITY_REQUEST_CHANNELS = {
+  '1372312806107512894': process.env.XBOX_PRIORITY_REQUEST_CHANNEL_ID,
+  '1369495333574545559': process.env.PS_PRIORITY_REQUEST_CHANNEL_ID,
+};
+
+const PRIORITY_STATUS_CHANNELS = {
+  '1372312806107512894': process.env.XBOX_PRIORITY_STATUS_CHANNEL_ID,
+  '1369495333574545559': process.env.PS_PRIORITY_STATUS_CHANNEL_ID,
+};
+
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
@@ -62,6 +72,7 @@ client.on("interactionCreate", async (interaction) => {
 const ShiftLog = require('./models/ShiftLog');
 const { v4: uuidv4 } = require('uuid');
 const { EmbedBuilder } = require('discord.js');
+const Priority = require('./models/Priority');
 
 if (interaction.isButton()) {
   const userId = interaction.user.id;
@@ -138,6 +149,124 @@ if (interaction.customId.startsWith('shift_start_')) {
   await sendShiftLog(interaction, logEmbed);
 }
 
+if (interaction.customId.startsWith('priority_accept_')) {
+  const requestId = interaction.customId.replace('priority_accept_', '');
+  const request = await Priority.findOne({ requestId });
+  if (!request || request.status !== 'pending') return;
+
+  request.status = 'approved';
+  request.approvedAt = new Date();
+  await request.save();
+
+  const embed = EmbedBuilder.from(interaction.message.embeds[0])
+    .setColor(0x2ecc71)
+    .addFields({ name: 'Status', value: `Approved by <@${interaction.user.id}>` });
+  await interaction.update({ embeds: [embed], components: [] });
+
+  const dmEmbed = new EmbedBuilder()
+    .setTitle('Priority Approved')
+    .setDescription('Use the buttons below to start your priority when ready.')
+    .setColor(0x2B2D31)
+    .setFooter({ text: `Request ID: ${requestId}` });
+
+  const dmRow = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId(`priority_start_${requestId}`).setLabel('Start Priority').setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId(`priority_cancel_${requestId}`).setLabel('Cancel').setStyle(ButtonStyle.Danger)
+  );
+
+  const user = await interaction.client.users.fetch(request.requesterId).catch(() => null);
+  if (user) {
+    await user.send({ embeds: [dmEmbed], components: [dmRow] }).catch(() => {});
+  }
+}
+
+if (interaction.customId.startsWith('priority_deny_')) {
+  const requestId = interaction.customId.replace('priority_deny_', '');
+  const request = await Priority.findOne({ requestId });
+  if (!request || request.status !== 'pending') return;
+
+  request.status = 'denied';
+  await request.save();
+
+  const embed = EmbedBuilder.from(interaction.message.embeds[0])
+    .setColor(0xff0000)
+    .addFields({ name: 'Status', value: `Denied by <@${interaction.user.id}>` });
+  await interaction.update({ embeds: [embed], components: [] });
+
+  const user = await interaction.client.users.fetch(request.requesterId).catch(() => null);
+  if (user) {
+    await user.send('❌ Your priority request was denied.').catch(() => {});
+  }
+}
+
+if (interaction.customId.startsWith('priority_start_')) {
+  const requestId = interaction.customId.replace('priority_start_', '');
+  const request = await Priority.findOne({ requestId });
+  if (!request || request.status !== 'approved') return;
+
+  request.status = 'active';
+  request.startedAt = new Date();
+  await request.save();
+
+  const statusChannelId = PRIORITY_STATUS_CHANNELS[request.guildId];
+  const statusChannel = statusChannelId ? await interaction.client.channels.fetch(statusChannelId).catch(() => null) : null;
+  if (statusChannel) {
+    const embed = new EmbedBuilder()
+      .setTitle('Active Priority')
+      .setColor(0x2B2D31)
+      .addFields(
+        { name: 'Type', value: request.type, inline: true },
+        { name: 'Requester', value: `<@${request.requesterId}>`, inline: true },
+        { name: 'Started', value: `<t:${Math.floor(Date.now()/1000)}:t>`, inline: true },
+        { name: 'Participants', value: request.participants.length ? request.participants.join(', ') : 'None' }
+      )
+      .setFooter({ text: `Request ID: ${requestId}` });
+    await statusChannel.send({ embeds: [embed] });
+  }
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId(`priority_end_${requestId}`).setLabel('End Priority').setStyle(ButtonStyle.Danger)
+  );
+
+  await interaction.update({ components: [row] });
+}
+
+if (interaction.customId.startsWith('priority_end_')) {
+  const requestId = interaction.customId.replace('priority_end_', '');
+  const request = await Priority.findOne({ requestId });
+  if (!request || request.status !== 'active') return;
+
+  request.status = 'ended';
+  request.endedAt = new Date();
+  await request.save();
+
+  const statusChannelId = PRIORITY_STATUS_CHANNELS[request.guildId];
+  const statusChannel = statusChannelId ? await interaction.client.channels.fetch(statusChannelId).catch(() => null) : null;
+  if (statusChannel) {
+    const embed = new EmbedBuilder()
+      .setTitle('Priority Ended')
+      .setColor(0x2B2D31)
+      .addFields(
+        { name: 'Type', value: request.type, inline: true },
+        { name: 'Ended', value: `<t:${Math.floor(Date.now()/1000)}:t>`, inline: true }
+      )
+      .setFooter({ text: `Request ID: ${requestId}` });
+    await statusChannel.send({ embeds: [embed] });
+  }
+
+  await interaction.update({ components: [] });
+}
+
+if (interaction.customId.startsWith('priority_cancel_')) {
+  const requestId = interaction.customId.replace('priority_cancel_', '');
+  const request = await Priority.findOne({ requestId });
+  if (!request || request.status !== 'approved') return;
+
+  request.status = 'canceled';
+  await request.save();
+
+  await interaction.update({ components: [] });
+}
 if (interaction.customId === 'shift_break') {
   const shift = activeShifts.get(userId);
   if (!shift || shift.onBreak) return;

--- a/models/Priority.js
+++ b/models/Priority.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+const prioritySchema = new mongoose.Schema({
+  guildId: { type: String, required: true },
+  requestId: { type: String, required: true, unique: true },
+  requesterId: { type: String, required: true },
+  participants: [String],
+  type: String,
+  reason: String,
+  estimatedDuration: Number,
+  status: {
+    type: String,
+    enum: ['pending', 'approved', 'active', 'ended', 'denied', 'canceled'],
+    default: 'pending'
+  },
+  createdAt: { type: Date, default: Date.now },
+  approvedAt: Date,
+  startedAt: Date,
+  endedAt: Date
+});
+
+module.exports = mongoose.model('Priority', prioritySchema);


### PR DESCRIPTION
## Summary
- create `Priority` model to track requests
- add `/priority` command for creating priority scene requests
- wire basic approve/deny/start/end flows with buttons
- track priority channels per platform via new constants

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_685b5b3649e48330b97f0c91089ec4df